### PR TITLE
Fix path handling in core runner and tests

### DIFF
--- a/imp/core/imp-execute.py
+++ b/imp/core/imp-execute.py
@@ -3,11 +3,15 @@ import subprocess
 
 print("🔥 IMP AI is initializing...")
 
+# Determine the project root dynamically instead of relying on a fixed path.  
+# This makes the script runnable from any location.
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
 # Start core AI processes
-subprocess.Popen(["python3", "/root/imp/core/imp-learning-memory.py"])
-subprocess.Popen(["python3", "/root/imp/core/imp-strategy-generator.py"])
-subprocess.Popen(["python3", "/root/imp/self-improvement/imp-code-updater.py"])
-subprocess.Popen(["python3", "/root/imp/security/imp-security-optimizer.py"])
-subprocess.Popen(["python3", "/root/imp/expansion/imp-cluster-manager.py"])
+subprocess.Popen(["python3", os.path.join(BASE_DIR, "core", "imp-learning-memory.py")])
+subprocess.Popen(["python3", os.path.join(BASE_DIR, "core", "imp-strategy-generator.py")])
+subprocess.Popen(["python3", os.path.join(BASE_DIR, "self-improvement", "imp-code-updater.py")])
+subprocess.Popen(["python3", os.path.join(BASE_DIR, "security", "imp-security-optimizer.py")])
+subprocess.Popen(["python3", os.path.join(BASE_DIR, "expansion", "imp-cluster-manager.py")])
 
 print("🚀 IMP is now running autonomously.")

--- a/imp/tests/run-all-tests.sh
+++ b/imp/tests/run-all-tests.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
-#chmod +x /root/imp/tests/run-all-tests.sh
+
+# Simple wrapper to execute all test modules relative to this script's location
+DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo "🚀 Running Full IMP System Test Suite..."
 
-python3 /root/imp/tests/test-core-functions.py
-python3 /root/imp/tests/test-security.py
-python3 /root/imp/tests/test-performance.py
-python3 /root/imp/tests/test-expansion.py
-python3 /root/imp/tests/test-self-improvement.py
-python3 /root/imp/tests/test-config.py
-python3 /root/imp/tests/test-logs.py
+python3 "$DIR/test-core-functions.py"
+python3 "$DIR/test-security.py"
+python3 "$DIR/test-performance.py"
+python3 "$DIR/test-expansion.py"
+python3 "$DIR/test-self-improvement.py"
+python3 "$DIR/test-config.py"
+python3 "$DIR/test-logs.py"
 
 echo "✅ All Tests Completed!"

--- a/imp/tests/test-config.py
+++ b/imp/tests/test-config.py
@@ -1,6 +1,8 @@
 import json
+import os
 
-CONFIG_FILE = "/root/imp/config/imp-personality.json"
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+CONFIG_FILE = os.path.join(BASE_DIR, "config", "imp-personality.json")
 
 def test_ai_personality():
     print("🤖 Validating AI Personality Settings...")

--- a/imp/tests/test-core-functions.py
+++ b/imp/tests/test-core-functions.py
@@ -1,7 +1,9 @@
 import json
+import os
 
-LEARNING_FILE = "/root/imp/logs/imp-learning-memory.json"
-STRATEGY_FILE = "/root/imp/logs/imp-strategy-plans.json"
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+LEARNING_FILE = os.path.join(BASE_DIR, "logs", "imp-learning-memory.json")
+STRATEGY_FILE = os.path.join(BASE_DIR, "logs", "imp-strategy-plans.json")
 
 def test_ai_learning():
     print("🔍 Testing AI Learning Memory...")

--- a/imp/tests/test-expansion.py
+++ b/imp/tests/test-expansion.py
@@ -1,6 +1,8 @@
 import json
+import os
 
-NODE_HEALTH_LOG = "/root/imp/logs/imp-node-health.json"
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+NODE_HEALTH_LOG = os.path.join(BASE_DIR, "logs", "imp-node-health.json")
 
 def test_node_health():
     print("🔗 Checking AI Cluster Nodes...")

--- a/imp/tests/test-logs.py
+++ b/imp/tests/test-logs.py
@@ -1,9 +1,12 @@
 import json
+import os
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 LOG_FILES = [
-    "/root/imp/logs/imp-activity-log.json",
-    "/root/imp/logs/imp-security-log.json",
-    "/root/imp/logs/imp-update-log.json"
+    os.path.join(BASE_DIR, "logs", "imp-activity-log.json"),
+    os.path.join(BASE_DIR, "logs", "imp-security-log.json"),
+    os.path.join(BASE_DIR, "logs", "imp-update-log.json"),
 ]
 
 def test_logging_system():

--- a/imp/tests/test-performance.py
+++ b/imp/tests/test-performance.py
@@ -1,12 +1,13 @@
 import os
 import json
 
-PERFORMANCE_LOG = "/root/imp/logs/imp-performance.json"
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PERFORMANCE_LOG = os.path.join(BASE_DIR, "logs", "imp-performance.json")
 
 def test_system_performance():
     print("📊 Running Performance Test...")
     
-    os.system("python3 /root/imp/logs/imp-log-manager.py")
+    os.system(f"python3 {os.path.join(BASE_DIR, 'logs', 'imp-log-manager.py')}")
     
     with open(PERFORMANCE_LOG, "r") as f:
         data = json.load(f)

--- a/imp/tests/test-security.py
+++ b/imp/tests/test-security.py
@@ -1,5 +1,8 @@
 import os
 import subprocess
+import os.path
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 def test_firewall():
     print("🛡️ Testing Firewall...")
@@ -10,7 +13,7 @@ def test_firewall():
 def test_intrusion_detection():
     print("🔍 Simulating Intrusion Attempt...")
     os.system("echo 'Failed password for root from 192.168.1.100' >> /var/log/auth.log")
-    os.system("python3 /root/imp/security/imp-threat-monitor.py")
+    os.system(f"python3 {os.path.join(BASE_DIR, 'security', 'imp-threat-monitor.py')}")
     print("✅ Intrusion Detection Test Executed! Check logs manually.")
 
 test_firewall()

--- a/imp/tests/test-self-improvement.py
+++ b/imp/tests/test-self-improvement.py
@@ -1,6 +1,8 @@
 import json
+import os
 
-UPDATE_LOG = "/root/imp/logs/imp-update-log.json"
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+UPDATE_LOG = os.path.join(BASE_DIR, "logs", "imp-update-log.json")
 
 def test_code_updates():
     print("🔄 Checking Code Updates...")


### PR DESCRIPTION
## Summary
- remove hard-coded `/root/imp` paths
- fix `imp/core/imp-execute.py` to determine base directory dynamically
- update all test modules to derive file paths from the test directory
- rewrite `run-all-tests.sh` with unix line endings and relative execution

## Testing
- `bash imp/tests/run-all-tests.sh` *(fails: FileNotFoundError and other assertions)*

------
https://chatgpt.com/codex/tasks/task_e_6845d5a0f9088321993ea50dddff4ad4